### PR TITLE
Add public tracking route and API integration

### DIFF
--- a/server/src/models/order.js
+++ b/server/src/models/order.js
@@ -1,0 +1,110 @@
+const crypto = require('crypto');
+
+class OrderModel {
+  constructor() {
+    this.records = [];
+    this.seedDemoRecords();
+  }
+
+  generateReference() {
+    return crypto.randomBytes(6).toString('hex').toUpperCase();
+  }
+
+  async create(payload = {}) {
+    const reference = payload.reference || this.generateReference();
+    let finalReference = reference;
+    if (
+      this.records.some((record) => String(record.reference).toUpperCase() === String(reference).toUpperCase())
+    ) {
+      finalReference = this.generateReference();
+    }
+
+    const record = {
+      id: payload.id || crypto.randomUUID?.() || crypto.randomBytes(8).toString('hex'),
+      reference: finalReference,
+      status: payload.status || 'menunggu',
+      history: Array.isArray(payload.history) ? payload.history : [],
+      attachments: Array.isArray(payload.attachments) ? payload.attachments : [],
+      createdAt: payload.createdAt || new Date().toISOString(),
+      updatedAt: payload.updatedAt || new Date().toISOString()
+    };
+
+    this.records.push(record);
+    return record;
+  }
+
+  seedDemoRecords() {
+    if (this.records.length) {
+      return;
+    }
+
+    const reference = 'DEMO-001';
+    this.records.push({
+      id: crypto.randomUUID?.() || crypto.randomBytes(8).toString('hex'),
+      reference,
+      status: 'diproses',
+      history: [
+        {
+          status: 'Pesanan diterima',
+          date: new Date().toISOString(),
+          note: 'Pesanan berhasil dicatat.'
+        },
+        {
+          status: 'Sedang diproses',
+          date: new Date().toISOString(),
+          note: 'Dokumen sedang diverifikasi.'
+        }
+      ],
+      attachments: [
+        {
+          name: 'Surat Permohonan',
+          url: '/files/contoh-surat-permohonan.pdf'
+        }
+      ],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    });
+  }
+
+  async findByReference(reference) {
+    if (!reference) {
+      return null;
+    }
+
+    const normalized = String(reference).trim().toUpperCase();
+    return this.records.find((record) => String(record.reference).toUpperCase() === normalized) || null;
+  }
+
+  serialize(record) {
+    if (!record) {
+      return null;
+    }
+
+    const attachments = Array.isArray(record.attachments)
+      ? record.attachments.map((item, index) => {
+          if (typeof item === 'string') {
+            return {
+              name: `Lampiran ${index + 1}`,
+              url: item
+            };
+          }
+
+          return item;
+        })
+      : [];
+
+    return {
+      reference: record.reference,
+      status: record.status,
+      history: Array.isArray(record.history) ? record.history : [],
+      attachments
+    };
+  }
+}
+
+const orderModel = new OrderModel();
+
+module.exports = {
+  OrderModel,
+  orderModel
+};

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -1,0 +1,41 @@
+const { orderModel } = require('./models/order.js');
+
+async function getTrackingPayload(reference, model = orderModel) {
+  const order = await model.findByReference(reference);
+  if (!order) {
+    return null;
+  }
+
+  return model.serialize(order);
+}
+
+function registerTrackingEndpoint(app, options = {}) {
+  if (!app || typeof app.get !== 'function') {
+    throw new Error('Instance Express app atau router dibutuhkan untuk mendaftarkan rute tracking.');
+  }
+
+  const model = options.orderModel || orderModel;
+
+  app.get('/api/tracking/:reference', async (req, res) => {
+    try {
+      const { reference } = req.params;
+      const payload = await getTrackingPayload(reference, model);
+
+      if (!payload) {
+        return res.status(404).json({ error: 'Kode tracking tidak valid atau tidak ditemukan.' });
+      }
+
+      return res.json(payload);
+    } catch (error) {
+      console.error('Gagal mengambil data tracking:', error);
+      return res.status(500).json({ error: 'Terjadi kesalahan pada server.' });
+    }
+  });
+
+  return app;
+}
+
+module.exports = {
+  registerTrackingEndpoint,
+  getTrackingPayload
+};

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,44 @@
+export async function fetchTracking(reference, options = {}) {
+  const { fetchFn = (typeof fetch !== 'undefined' ? fetch : null), signal } = options;
+
+  if (!reference) {
+    throw new Error('Nomor referensi diperlukan.');
+  }
+
+  if (typeof fetchFn !== 'function') {
+    throw new Error('Fungsi fetch tidak tersedia di lingkungan ini.');
+  }
+
+  const trimmed = String(reference).trim();
+  if (!trimmed) {
+    throw new Error('Nomor referensi diperlukan.');
+  }
+
+  const response = await fetchFn(`/api/tracking/${encodeURIComponent(trimmed)}`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    },
+    signal
+  });
+
+  if (!response.ok) {
+    let message = 'Kode tracking tidak ditemukan.';
+    try {
+      const payload = await response.json();
+      if (payload && payload.error) {
+        message = payload.error;
+      }
+    } catch (error) {
+      // abaikan, gunakan pesan bawaan
+    }
+
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export default {
+  fetchTracking
+};

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,83 @@
+import { renderLayout } from './components/layout.js';
+import TrackingPage from './pages/tracking/tracking.js';
+
+function parseRoute(route = '') {
+  const [path, query = ''] = route.split('?');
+  const searchParams = new URLSearchParams(query);
+  return { path, searchParams };
+}
+
+function renderRoute(route, root, options = {}) {
+  const { path, searchParams } = parseRoute(route);
+
+  if (path === '#/tracking') {
+    const trackingOptions = {
+      ...options.tracking,
+      initialReference: options.tracking?.initialReference || searchParams.get('ref') || searchParams.get('reference')
+    };
+    const page = new TrackingPage(root, trackingOptions);
+    page.render();
+    return;
+  }
+
+  if (root) {
+    root.innerHTML = '<p>Halaman tidak ditemukan.</p>';
+  }
+}
+
+export function initApp({ mountSelector = '#app', layoutOptions = {}, trackingOptions = {} } = {}) {
+  const mountPoint = document.querySelector(mountSelector);
+  if (!mountPoint) {
+    throw new Error(`Elemen dengan selector "${mountSelector}" tidak ditemukan.`);
+  }
+
+  const initialLayoutOptions = { ...layoutOptions, activePath: '#/tracking' };
+  mountPoint.innerHTML = renderLayout('<div class="app__content"></div>', initialLayoutOptions);
+
+  const container = mountPoint.querySelector('.app__content');
+  if (!container) {
+    throw new Error('Container konten tidak tersedia.');
+  }
+
+  function updateNavigation(route) {
+    const { path: currentPath } = parseRoute(route);
+    const nav = mountPoint.querySelector('.layout__nav');
+    if (!nav) {
+      return;
+    }
+
+    const links = Array.from(nav.querySelectorAll('.layout__link'));
+    links.forEach((link) => {
+      const href = link.getAttribute('href');
+      if (!href) {
+        return;
+      }
+
+      const normalized = href.startsWith('#') ? href : href.replace(/^[^#]*/, '');
+      const { path } = parseRoute(normalized);
+      const isActive = path === currentPath;
+      if (isActive) {
+        link.classList.add('layout__link--active');
+      } else {
+        link.classList.remove('layout__link--active');
+      }
+    });
+  }
+
+  function handleRouteChange() {
+    if (!window.location.hash) {
+      window.location.hash = '#/tracking';
+    }
+
+    const route = window.location.hash || '#/tracking';
+    renderRoute(route, container, { tracking: trackingOptions });
+    updateNavigation(route);
+  }
+
+  window.addEventListener('hashchange', handleRouteChange);
+  handleRouteChange();
+}
+
+export default {
+  initApp
+};

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,0 +1,33 @@
+function renderNavigation(isAuthenticated = false, activePath = '#/tracking') {
+  const linkClass = (path) =>
+    `layout__link${activePath === path ? ' layout__link--active' : ''}`;
+  const authLinks = isAuthenticated
+    ? `<a class="${linkClass('#/dashboard')}" href="#/dashboard">Dashboard</a>`
+    : `<a class="${linkClass('#/login')}" href="#/login">Masuk</a>`;
+
+  return `
+    <nav class="layout__nav">
+      <a class="${linkClass('#/')}" href="#/">Beranda</a>
+      <a class="${linkClass('#/tracking')}" href="#/tracking">Lacak Pesanan</a>
+      ${authLinks}
+    </nav>
+  `;
+}
+
+export function renderLayout(content, options = {}) {
+  const { title = 'SobatIzin', isAuthenticated = false, activePath = '#/tracking' } = options;
+
+  return `
+    <div class="layout">
+      <header class="layout__header">
+        <h1 class="layout__title">${title}</h1>
+        ${renderNavigation(isAuthenticated, activePath)}
+      </header>
+      <main class="layout__content">${content}</main>
+    </div>
+  `;
+}
+
+export default {
+  renderLayout
+};

--- a/src/pages/tracking/tracking.js
+++ b/src/pages/tracking/tracking.js
@@ -1,0 +1,163 @@
+import { fetchTracking } from '../../api.js';
+
+function renderHistory(history = []) {
+  if (!history.length) {
+    return '<p class="tracking__empty">Belum ada riwayat.</p>';
+  }
+
+  const items = history
+    .map((item) => {
+      if (typeof item === 'string') {
+        return `<li class="tracking__history-item">${item}</li>`;
+      }
+
+      const { status, date, note } = item;
+      const parts = [status, date, note].filter(Boolean).join(' • ');
+      return `<li class="tracking__history-item">${parts}</li>`;
+    })
+    .join('');
+
+  return `<ol class="tracking__history">${items}</ol>`;
+}
+
+function renderAttachments(attachments = []) {
+  if (!attachments.length) {
+    return '';
+  }
+
+  const items = attachments
+    .map((file, index) => {
+      if (typeof file === 'string') {
+        return `<li class="tracking__attachment-item"><a href="${file}" target="_blank" rel="noopener noreferrer">Lampiran ${index + 1}</a></li>`;
+      }
+
+      const { name = `Lampiran ${index + 1}`, url = '#' } = file || {};
+      return `<li class="tracking__attachment-item"><a href="${url}" target="_blank" rel="noopener noreferrer">${name}</a></li>`;
+    })
+    .join('');
+
+  return `
+    <section class="tracking__attachments">
+      <h3 class="tracking__section-title">Berkas Terkait</h3>
+      <ul class="tracking__attachment-list">${items}</ul>
+    </section>
+  `;
+}
+
+export class TrackingPage {
+  constructor(root, options = {}) {
+    this.root = root;
+    this.options = options;
+    this.state = {
+      loading: false,
+      error: null,
+      data: null
+    };
+    this.initialReference = options.initialReference || '';
+    this.hasPrefetched = false;
+  }
+
+  setState(patch) {
+    this.state = { ...this.state, ...patch };
+    this.render();
+  }
+
+  async performLookup(reference) {
+    const normalized = String(reference || '').trim();
+    if (!normalized) {
+      this.setState({ loading: false, error: 'Nomor referensi diperlukan.' });
+      return;
+    }
+
+    this.initialReference = normalized;
+
+    this.setState({ loading: true, error: null });
+
+    try {
+      const data = await fetchTracking(normalized, this.options.apiOptions || {});
+      this.setState({ loading: false, data });
+    } catch (error) {
+      this.setState({ loading: false, error: error.message || 'Terjadi kesalahan.' });
+    }
+  }
+
+  async handleSubmit(event) {
+    event.preventDefault();
+    const form = event.target;
+    const input = form.querySelector('input[name="reference"]');
+    const reference = input ? input.value : '';
+
+    await this.performLookup(reference);
+  }
+
+  renderContent() {
+    const { loading, error, data } = this.state;
+
+    if (loading) {
+      return '<p class="tracking__loading">Mengambil data...</p>';
+    }
+
+    if (error) {
+      return `<p class="tracking__error" role="alert">${error}</p>`;
+    }
+
+    if (!data) {
+      return '<p class="tracking__hint">Masukkan kode tracking untuk melihat status order Anda.</p>';
+    }
+
+    const { reference, status, history = [], attachments = [] } = data;
+
+    return `
+      <section class="tracking__result" aria-live="polite">
+        <h2 class="tracking__status">Status: ${status || 'Tidak tersedia'}</h2>
+        <p class="tracking__reference">Kode Tracking: <strong>${reference}</strong></p>
+        <section class="tracking__history-wrapper">
+          <h3 class="tracking__section-title">Riwayat</h3>
+          ${renderHistory(history)}
+        </section>
+        ${renderAttachments(attachments)}
+      </section>
+    `;
+  }
+
+  render() {
+    if (!this.root) {
+      return;
+    }
+
+    this.root.innerHTML = `
+      <section class="tracking">
+        <form class="tracking__form">
+          <label class="tracking__label" for="tracking-reference">Nomor Order / Kode Tracking</label>
+          <div class="tracking__input-group">
+            <input
+              id="tracking-reference"
+              name="reference"
+              class="tracking__input"
+              placeholder="Contoh: ABC123"
+              required
+            />
+            <button class="tracking__button" type="submit">Lacak</button>
+          </div>
+        </form>
+        <div class="tracking__body">${this.renderContent()}</div>
+      </section>
+    `;
+
+    const form = this.root.querySelector('.tracking__form');
+    if (form) {
+      form.addEventListener('submit', (event) => this.handleSubmit(event));
+      const input = form.querySelector('input[name="reference"]');
+      if (input && this.initialReference && !this.hasPrefetched) {
+        input.value = this.initialReference;
+        const shouldAutoFetch = this.options.autoFetch !== false;
+        if (shouldAutoFetch) {
+          this.hasPrefetched = true;
+          this.performLookup(this.initialReference);
+        }
+      }
+    }
+  }
+}
+
+export default TrackingPage;


### PR DESCRIPTION
## Summary
- add a hash-based tracking route that renders the new tracking page and keeps navigation highlights in sync
- implement a tracking page component that calls the shared API helper to fetch order status, history, and attachments with error handling and optional auto-lookup
- expose a backend tracking endpoint with an order model that seeds demo data and ensures each order has a reference code while serialising public-safe fields
- update the layout navigation so both public visitors and authenticated clients can reach the tracking screen easily

## Testing
- node - <<'NODE'
const { registerTrackingEndpoint, getTrackingPayload } = require('./server/src/routes.js');

const router = {
  routes: {},
  get(path, handler) {
    this.routes[path] = handler;
  }
};

registerTrackingEndpoint(router);

(async () => {
  const ok = await getTrackingPayload('DEMO-001');
  console.log('payload', ok);

  const handler = router.routes['/api/tracking/:reference'];
  if (handler) {
    const req = { params: { reference: 'DEMO-001' } };
    const res = {
      statusCode: 200,
      payload: null,
      status(code) {
        this.statusCode = code;
        return this;
      },
      json(data) {
        this.payload = data;
        console.log('res', this.statusCode, data);
      }
    };

    await handler(req, res);
  }
})();
NODE

------
https://chatgpt.com/codex/tasks/task_b_68ce236462a48333872839d013f374b3