### PR TITLE
Implement validated contact submission workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+logs/*.log
+logs/*.json
+.env
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+server/dist/
+server/node_modules/
+client/node_modules/
+client/dist/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Sobatizin Contact Service
+
+This repository contains a lightweight Express + React setup that demonstrates how contact form submissions are validated on the server and persisted to a log file.
+
+## Prerequisites
+
+- Node.js 18+
+- npm 9+
+
+## Getting started
+
+### Install dependencies
+
+```bash
+npm --prefix server install
+```
+
+### Run the development API server
+
+```bash
+npm --prefix server run dev
+```
+
+The server listens on port `4000` by default. You can set a custom port with the `PORT` environment variable.
+
+### Build the production bundle
+
+```bash
+npm --prefix server run build
+```
+
+### Start the compiled server
+
+```bash
+npm --prefix server start
+```
+
+## Contact endpoint
+
+`POST /api/contact`
+
+Body parameters:
+
+| Field   | Type   | Notes |
+| ------- | ------ | ----- |
+| `name`  | string | Required. |
+| `email` | string | Optional, but either `email` or `phone` must be provided. Must be a valid email address when present. |
+| `phone` | string | Optional, but either `phone` or `email` must be provided. Accepts digits, spaces, parentheses, `+`, `-`, and `.` characters. |
+| `service` | string | Required. |
+| `message` | string | Required. |
+
+The request is validated with a [Zod](https://zod.dev) schema on the server. Invalid requests return a `400` response with structured validation errors that the UI can surface.
+
+### Logging
+
+Valid submissions are appended to `logs/contact-submissions.log` (relative to the repository root). Each line contains a JSON object with the validated submission payload and metadata describing when and from which IP address the request was received.
+
+The log directory is created automatically if it does not exist.
+
+## Front-end form
+
+`client/src/components/ContactForm.jsx` demonstrates how to POST to the internal `/api/contact` endpoint, handle validation feedback, and display success messages without relying on `window.alert`.
+
+## Project status
+
+This project currently focuses on the server endpoint and the contact form component. You can integrate the form component into any existing React application or extend the server as needed.

--- a/client/src/components/ContactForm.jsx
+++ b/client/src/components/ContactForm.jsx
@@ -1,0 +1,193 @@
+import { useState } from 'react';
+
+const initialFormState = {
+  name: '',
+  email: '',
+  phone: '',
+  service: '',
+  message: ''
+};
+
+function ContactForm() {
+  const [formData, setFormData] = useState(initialFormState);
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [formStatus, setFormStatus] = useState({ type: 'idle', message: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const updateField = (event) => {
+    const { name, value } = event.target;
+    setFormData((previous) => ({
+      ...previous,
+      [name]: value
+    }));
+    setFieldErrors((previous) => ({
+      ...previous,
+      [name]: undefined,
+      form: undefined
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    setIsSubmitting(true);
+    setFieldErrors({});
+    setFormStatus({ type: 'idle', message: '' });
+
+    try {
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
+      });
+
+      const payload = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const nextErrors = {};
+        if (Array.isArray(payload.errors)) {
+          for (const error of payload.errors) {
+            if (error?.field) {
+              nextErrors[error.field] = error.message;
+            } else {
+              nextErrors.form = error?.message ?? 'Something went wrong. Please try again.';
+            }
+          }
+        }
+
+        setFieldErrors(nextErrors);
+        setFormStatus({
+          type: 'error',
+          message: payload.message ?? 'We could not submit your request. Please check the highlighted fields.'
+        });
+        return;
+      }
+
+      setFormData(initialFormState);
+      setFormStatus({
+        type: 'success',
+        message: payload.message ?? 'Thank you for reaching out! Our team will contact you soon.'
+      });
+    } catch (error) {
+      console.error('Unable to submit contact form', error);
+      setFormStatus({
+        type: 'error',
+        message: 'We are unable to submit your request right now. Please try again shortly.'
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      <div>
+        <label htmlFor="name">Name</label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          value={formData.name}
+          onChange={updateField}
+          aria-invalid={Boolean(fieldErrors.name)}
+          aria-describedby={fieldErrors.name ? 'name-error' : undefined}
+        />
+        {fieldErrors.name ? (
+          <p id="name-error" role="alert">
+            {fieldErrors.name}
+          </p>
+        ) : null}
+      </div>
+
+      <div>
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          value={formData.email}
+          onChange={updateField}
+          aria-invalid={Boolean(fieldErrors.email)}
+          aria-describedby={fieldErrors.email ? 'email-error' : undefined}
+        />
+        {fieldErrors.email ? (
+          <p id="email-error" role="alert">
+            {fieldErrors.email}
+          </p>
+        ) : null}
+      </div>
+
+      <div>
+        <label htmlFor="phone">Phone</label>
+        <input
+          id="phone"
+          name="phone"
+          type="tel"
+          value={formData.phone}
+          onChange={updateField}
+          aria-invalid={Boolean(fieldErrors.phone)}
+          aria-describedby={fieldErrors.phone ? 'phone-error' : undefined}
+        />
+        {fieldErrors.phone ? (
+          <p id="phone-error" role="alert">
+            {fieldErrors.phone}
+          </p>
+        ) : null}
+      </div>
+
+      <div>
+        <label htmlFor="service">Service</label>
+        <input
+          id="service"
+          name="service"
+          type="text"
+          value={formData.service}
+          onChange={updateField}
+          aria-invalid={Boolean(fieldErrors.service)}
+          aria-describedby={fieldErrors.service ? 'service-error' : undefined}
+        />
+        {fieldErrors.service ? (
+          <p id="service-error" role="alert">
+            {fieldErrors.service}
+          </p>
+        ) : null}
+      </div>
+
+      <div>
+        <label htmlFor="message">Message</label>
+        <textarea
+          id="message"
+          name="message"
+          rows={4}
+          value={formData.message}
+          onChange={updateField}
+          aria-invalid={Boolean(fieldErrors.message)}
+          aria-describedby={fieldErrors.message ? 'message-error' : undefined}
+        />
+        {fieldErrors.message ? (
+          <p id="message-error" role="alert">
+            {fieldErrors.message}
+          </p>
+        ) : null}
+      </div>
+
+      {fieldErrors.form ? (
+        <p role="alert">{fieldErrors.form}</p>
+      ) : null}
+
+      {formStatus.type !== 'idle' ? (
+        <p role={formStatus.type === 'error' ? 'alert' : undefined}>
+          {formStatus.message}
+        </p>
+      ) : null}
+
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Sending…' : 'Send message'}
+      </button>
+    </form>
+  );
+}
+
+export default ContactForm;

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "sobatizin-server",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "test": "npm run build"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.30",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+import contactRouter from './routes/contact';
+
+const app = express();
+
+app.use(express.json());
+app.use('/api/contact', contactRouter);
+
+const port = Number(process.env.PORT ?? 4000);
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+export default app;

--- a/server/src/routes/contact.ts
+++ b/server/src/routes/contact.ts
@@ -1,0 +1,113 @@
+import type { Request, Response } from 'express';
+import { Router } from 'express';
+import { z } from 'zod';
+import { appendFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const optionalEmailSchema = z.preprocess(
+  (value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmed = value.trim();
+    return trimmed === '' ? undefined : trimmed;
+  },
+  z.string().email('Please provide a valid email address').optional()
+);
+
+const optionalPhoneSchema = z.preprocess(
+  (value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmed = value.trim();
+    return trimmed === '' ? undefined : trimmed;
+  },
+  z
+    .string()
+    .regex(/^[+\d\s().-]{7,}$/u, 'Please provide a valid phone number')
+    .optional()
+);
+
+const contactSchema = z
+  .object({
+    name: z
+      .string({ required_error: 'Name is required' })
+      .trim()
+      .min(1, 'Name is required'),
+    email: optionalEmailSchema,
+    phone: optionalPhoneSchema,
+    service: z
+      .string({ required_error: 'Service is required' })
+      .trim()
+      .min(1, 'Service is required'),
+    message: z
+      .string({ required_error: 'Message is required' })
+      .trim()
+      .min(1, 'Message is required')
+  })
+  .refine((data) => Boolean(data.email || data.phone), {
+    message: 'Either an email or phone number is required',
+    path: ['form']
+  });
+
+const logFilePath = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'logs',
+  'contact-submissions.log'
+);
+
+async function ensureLogDirExists(): Promise<void> {
+  const logDir = path.dirname(logFilePath);
+  await mkdir(logDir, { recursive: true });
+}
+
+const router = Router();
+
+router.post('/', async (req: Request, res: Response) => {
+  const parseResult = contactSchema.safeParse(req.body);
+
+  if (!parseResult.success) {
+    const errors = parseResult.error.errors.map((issue) => ({
+      field: issue.path.join('.') || null,
+      message: issue.message
+    }));
+
+    return res.status(400).json({
+      message: 'Validation failed',
+      errors
+    });
+  }
+
+  const submission = parseResult.data;
+
+  const metadata = {
+    receivedAt: new Date().toISOString(),
+    ip: req.ip,
+    forwardedFor: req.headers['x-forwarded-for'] ?? null,
+    userAgent: req.headers['user-agent'] ?? null
+  };
+
+  try {
+    await ensureLogDirExists();
+    await appendFile(logFilePath, `${JSON.stringify({ submission, metadata })}\n`, {
+      encoding: 'utf8'
+    });
+  } catch (error) {
+    console.error('Unable to write contact submission log:', error);
+    return res.status(500).json({
+      message: 'Unable to save your message right now. Please try again later.'
+    });
+  }
+
+  return res.status(201).json({
+    message: 'Your message has been received. We will reach out soon.'
+  });
+});
+
+export default router;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add an Express-based `/api/contact` endpoint with Zod validation and IP-aware logging to `logs/contact-submissions.log`
- wire up the React `ContactForm` to submit to the backend and surface structured server validation feedback
- document the server workflow, logging location, and component usage in the README

## Testing
- npm --prefix server install *(fails: 403 Forbidden while fetching `@types/express` in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd829cd36c8333af0c4a03432fedec